### PR TITLE
Add 2.25" flipper to asset lib

### DIFF
--- a/addons/vpx_lightmapper/assets/Pinball Core Parts.blend
+++ b/addons/vpx_lightmapper/assets/Pinball Core Parts.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bdf09657c2d63dbf96ef77da4de29eaca3d15ad5a9744928cff78cf51f1f79d0
-size 105142035
+oid sha256:1841ca97d9e7517e890d2fad171f525a8c784935934d0e3cc7001015d1c94d33
+size 107669607


### PR DESCRIPTION
This PR adds a 2.25" flipper to the asset lib that I've modeled from scratch. Material was done in Substance Painter and might be further tweaked with a bit more wear.

<img width="250" src="https://user-images.githubusercontent.com/70426/180095419-5b7d9fa6-e82d-4034-aeb4-e8d030731d58.png">
