### PR TITLE
Strip embedded NUL from script text on export

### DIFF
--- a/addons/vpx_lightmapper/vlm_export.py
+++ b/addons/vpx_lightmapper/vlm_export.py
@@ -707,7 +707,10 @@ def export_vpx(op, context):
                             # Old arrays: just remove them
                             in_old_arrays = 1
                         else:
-                            new_code += line
+                            # Strip any embedded NUL: harmless in the BIFF stream itself (see get_raw_string above),
+                            # but VPX's script editor treats the text as NUL-terminated and silently truncates the
+                            # display (and a save from that state would drop everything past it, arrays included).
+                            new_code += line.replace('\x00', '')
                             new_code += '\n'
                     if in_old_arrays < 2:
                         new_code += '\n' + get_script_arrays(bake_col, result_col)


### PR DESCRIPTION
## Summary
Follow-up to #38. After that fix, the BIFF stream itself correctly handles a script containing an embedded NUL byte (`get_raw_string` no longer truncates the read), but VPX's script editor still displays it wrong: `codeview.cpp` sets the Scintilla buffer via `SCI_SETTEXT` with a plain null-terminated `c_str()`, which has no length parameter, so any embedded `\x00` in the script silently truncates the *editor's display* at that point — including everything injected after it (the VLM arrays block).

Beyond being confusing, this is a real data-loss risk: if a table with an embedded NUL is opened and saved from VPX's editor while in this truncated state, everything past the NUL — including the injected arrays — would be silently dropped from the save.

- Strips embedded NUL bytes from the rewritten script text on export (harmless in VBScript source; this is stray leftover byte, not meaningful content).
- Verified against a real table with this exact issue: before the fix, VPX's script editor showed the script ending mid-file at the byte where the NUL occurred; after the fix, the full script (arrays included) is visible.

## Test plan
- [x] Reproduced against a real table whose script contains an embedded NUL byte at a fixed position; confirmed VPX's editor cut off the display at that exact line before the fix.
- [x] Applied the fix, re-exported, confirmed the exported script no longer contains the NUL byte and the full script (including the VLM arrays section) is visible in VPX's editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)